### PR TITLE
chore(release): hydra 2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Apply the plugin in your **app module's `build.gradle.kts`**:
 ```kotlin
 plugins {
     id("com.android.application")
-    id("tech.thessemaj.hydra") version "2.4.0"
+    id("tech.thessemaj.hydra") version "2.8.0"
 }
 ```
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 // JitPack consumers are unaffected: it archives whatever the build publishes
 // and keeps serving historical tags built with the old group.
 group = "tech.thessemaj"
-version = findProperty("VERSION_NAME")?.toString() ?: "2.7.0"
+version = findProperty("VERSION_NAME")?.toString() ?: "2.8.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
Version bump for the 2.8.0 release (bundled runtime 4.8.0).

Also updates the README integration snippet, which still advertised `version "2.4.0"` — four releases behind, so a copy-paste integration was pinning an older runtime.